### PR TITLE
feat: Generate unique ids for messages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
+	github.com/matoous/go-nanoid/v2 v2.0.0 // indirect
 	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,10 @@ github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47e
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/matoous/go-nanoid v1.5.0 h1:VRorl6uCngneC4oUQqOYtO3S0H5QKFtKuKycFG3euek=
+github.com/matoous/go-nanoid v1.5.0/go.mod h1:zyD2a71IubI24efhpvkJz+ZwfwagzgSO6UNiFsZKN7U=
+github.com/matoous/go-nanoid/v2 v2.0.0 h1:d19kur2QuLeHmJBkvYkFdhFBzLoo1XVm2GgTpL+9Tj0=
+github.com/matoous/go-nanoid/v2 v2.0.0/go.mod h1:FtS4aGPVfEkxKxhdWPAspZpZSh1cOjtM7Ej/So3hR0g=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe h1:iruDEfMl2E6fbMZ9s0scYfZQ84/6SPL6zC8ACM2oIL0=
 github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/achintya-7/go_socketio/controllers"
 	"github.com/achintya-7/go_socketio/models"
 	socketio "github.com/googollee/go-socket.io"
-	"github.com/matoous/go-nanoid/v2"
+	gonanoid "github.com/matoous/go-nanoid/v2"
 )
 
 func main() {
@@ -31,9 +31,6 @@ func main() {
 	})
 
 	server.OnEvent("/", "send", func(c socketio.Conn, r string) {
-		// TODO : generate a random number or uuid and add it to the req struct
-		// can use the key and value payer as {messageId: "dkbkfnbfbn"}
-
 		var req models.SendMessageReq
 		err := json.Unmarshal([]byte(r), &req)
 		if err != nil {
@@ -52,11 +49,11 @@ func main() {
 		}
 
 		res := models.SendMessageRes{
-			UserId: req.UserId,
-			RoomId: req.RoomId,
-			Content: req.Content,
+			UserId:      req.UserId,
+			RoomId:      req.RoomId,
+			Content:     req.Content,
 			ContentType: req.ContentType,
-			MessageId: uid,
+			MessageId:   uid,
 		}
 
 		server.BroadcastToRoom("/", req.RoomId.String(), "send", res)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/achintya-7/go_socketio/controllers"
 	"github.com/achintya-7/go_socketio/models"
 	socketio "github.com/googollee/go-socket.io"
+	"github.com/matoous/go-nanoid/v2"
 )
 
 func main() {
@@ -39,12 +40,23 @@ func main() {
 			fmt.Println("Unable to parse :", err)
 		}
 
+		// generate a uid for the message
+		// ? Could the message ID by a timestamp + sender hash instead?
+		// In any case this should satisfy constraints
+		uid, err := gonanoid.New()
+		if err != nil {
+			fmt.Printf("unable to generate nanoid: %v\n", err)
+			// ? shouldn't proceed if we fail to generate an ID, or is there a failure signal
+			// we can send to let the client know we failed?
+			return
+		}
+
 		res := models.SendMessageRes{
 			UserId: req.UserId,
 			RoomId: req.RoomId,
 			Content: req.Content,
 			ContentType: req.ContentType,
-			MessageId: "323424234",
+			MessageId: uid,
 		}
 
 		server.BroadcastToRoom("/", req.RoomId.String(), "send", res)


### PR DESCRIPTION
## What
Generate a UID for messages with go-nanoid

## Why
It was a TODO ;)

## Comments
There could be other strategies to uniquely tag messages, with one being
the request timestamp + sender derivative. However the PR's use of
nanoid should satisfy requirements I believe.
